### PR TITLE
Add form to allow users to join an event 

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from events.models import Participant
+
+
+class JoinForm(forms.ModelForm):
+    class Meta:
+        model = Participant
+        fields = ('name','event')
+        widgets = {
+            'name': forms.TextInput(
+                attrs={ 'class':'form-control',
+                        'placeholder':'Player name'}),
+            'event': forms.HiddenInput()
+        }

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="card">
     <div class="card-body">
-        <h2 class="card-title">Register for "{{ event.name }}"</h2>
-        <div class="card-subtitle mb-2 text-muted"> To register for the event, please enter your details below.</div>
+        <h2 class="card-title">Registration for "{{ event.name }}"</h2>
+        <div class="card-subtitle mb-2 text-muted"> To join the event, please enter your details below.</div>
         </br>
         {% if form.non_field_errors %}
             {% for error in form.non_field_errors %}

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -3,6 +3,9 @@
 {% block content %}
 <div class="card">
     <div class="card-body">
+        <h2 class="card-title">Register for "{{ event.name }}"</h2>
+        <div class="card-subtitle mb-2 text-muted"> To register for the event, please enter your details below.</div>
+        </br>
         {% if form.non_field_errors %}
             {% for error in form.non_field_errors %}
                 <div class="alert alert-danger">

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -1,37 +1,31 @@
-{% load static %}
-<html>
-    <head>
-            <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
-            <link rel="stylesheet" type="text/css" href="{% static 'events/events.css' %}">
+{% extends 'base.html' %}
 
-    </head>
-    <body>
-        <div class="card">
-            <div class="card-body">
-                {% if form.errors %}
-                    {% for error in form.name.errors %}
-                            <div class="alert alert-danger">
-                                <strong>{{ error|escape }}</strong>
-                            </div>
-                    {% endfor %}
-                    {% for error in form.non_field_errors %}
-                        <div class="alert alert-danger">
-                            <strong>{{ error|escape }}</strong>
-                        </div>
-                    {% endfor %}
-                {% endif %}
-                <form method="post" novalidate>
-                    {% csrf_token %}
-                    {% for field in form %}
-                        <div class="form-group">
-                            <div class="fieldWrapper">
-                                {{ field }}
-                            </div>
-                        </div>
-                    {% endfor %}
-                    <button type="submit" class="btn btn-success">Join Event</button>
-                </form>
-            </div>
-        </div>
-    </body>
-</html>
+{% block content %}
+<div class="card">
+    <div class="card-body">
+        {% if form.errors %}
+            {% for error in form.name.errors %}
+                    <div class="alert alert-danger">
+                        <strong>{{ error|escape }}</strong>
+                    </div>
+            {% endfor %}
+            {% for error in form.non_field_errors %}
+                <div class="alert alert-danger">
+                    <strong>{{ error|escape }}</strong>
+                </div>
+            {% endfor %}
+        {% endif %}
+        <form method="post" novalidate>
+            {% csrf_token %}
+            {% for field in form %}
+                <div class="form-group">
+                    <div class="fieldWrapper">
+                        {{ field }}
+                    </div>
+                </div>
+            {% endfor %}
+            <button type="submit" class="btn btn-success">Join Event</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -1,0 +1,37 @@
+{% load static %}
+<html>
+    <head>
+            <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+            <link rel="stylesheet" type="text/css" href="{% static 'events/events.css' %}">
+
+    </head>
+    <body>
+        <div class="card">
+            <div class="card-body">
+                {% if form.errors %}
+                    {% for error in form.name.errors %}
+                            <div class="alert alert-danger">
+                                <strong>{{ error|escape }}</strong>
+                            </div>
+                    {% endfor %}
+                    {% for error in form.non_field_errors %}
+                        <div class="alert alert-danger">
+                            <strong>{{ error|escape }}</strong>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+                <form method="post" novalidate>
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="form-group">
+                            <div class="fieldWrapper">
+                                {{ field }}
+                            </div>
+                        </div>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-success">Join Event</button>
+                </form>
+            </div>
+        </div>
+    </body>
+</html>

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %} Join Event | {{ event.name }}{% endblock %}
+
 {% block content %}
 <div class="card">
     <div class="card-body">

--- a/events/templates/events/join_event.html
+++ b/events/templates/events/join_event.html
@@ -3,12 +3,7 @@
 {% block content %}
 <div class="card">
     <div class="card-body">
-        {% if form.errors %}
-            {% for error in form.name.errors %}
-                    <div class="alert alert-danger">
-                        <strong>{{ error|escape }}</strong>
-                    </div>
-            {% endfor %}
+        {% if form.non_field_errors %}
             {% for error in form.non_field_errors %}
                 <div class="alert alert-danger">
                     <strong>{{ error|escape }}</strong>
@@ -17,6 +12,8 @@
         {% endif %}
         <form method="post" novalidate>
             {% csrf_token %}
+            <label for="{{ form.name.id_for_label }}">Player name</label>
+            <!-- For loop used to render both the field name and the required hidden input used to store the event-->
             {% for field in form %}
                 <div class="form-group">
                     <div class="fieldWrapper">
@@ -24,6 +21,11 @@
                     </div>
                 </div>
             {% endfor %}
+            {% if form.name.errors %}
+                {% for error in form.name.errors %}
+                    <p class="font-italic text-danger"><strong>{{ error|escape }}</strong></p>
+                {% endfor %}
+            {% endif %}
             <button type="submit" class="btn btn-success">Join Event</button>
         </form>
     </div>

--- a/events/urls.py
+++ b/events/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from events.views import EventListView, EventView
+from events.views import EventListView, EventView, JoinView
 
 urlpatterns = [
     path('', EventListView.as_view(), name='event_list_view'),
-    path('<int:pk>/', EventView.as_view(), name='event_view')
+    path('<int:pk>/', EventView.as_view(), name='event_view'),
+    path('<int:event_id>/join/', JoinView.as_view(), name='join_view'),
 ]

--- a/events/views.py
+++ b/events/views.py
@@ -1,6 +1,5 @@
 from events.models import Event, Participant
 from events.forms import JoinForm
-from  django.urls import reverse
 from django.views.generic import CreateView, DetailView, ListView
 
 class EventListView(ListView):

--- a/events/views.py
+++ b/events/views.py
@@ -1,5 +1,7 @@
-from events.models import Event
-from django.views.generic import DetailView, ListView
+from events.models import Event, Participant
+from events.forms import JoinForm
+from  django.urls import reverse
+from django.views.generic import CreateView, DetailView, ListView
 
 class EventListView(ListView):
     template_name = 'events/event_list.html'
@@ -8,3 +10,14 @@ class EventListView(ListView):
 class EventView(DetailView):
     template_name = 'events/event.html'
     model = Event
+
+class JoinView(CreateView):
+    template_name = 'events/join_event.html'
+    model = Participant
+    form_class = JoinForm
+
+    def get_success_url(self):
+        return reverse('event_view', kwargs={'pk':self.kwargs['event_id']})
+
+    def get_initial(self):
+        return {'event': Event.objects.get(pk=self.kwargs['event_id'])}

--- a/events/views.py
+++ b/events/views.py
@@ -15,9 +15,7 @@ class JoinView(CreateView):
     template_name = 'events/join_event.html'
     model = Participant
     form_class = JoinForm
-
-    def get_success_url(self):
-        return reverse('event_view', kwargs={'pk':self.kwargs['event_id']})
+    success_url = '/events'
 
     def get_initial(self):
         return {'event': Event.objects.get(pk=self.kwargs['event_id'])}

--- a/events/views.py
+++ b/events/views.py
@@ -16,5 +16,10 @@ class JoinView(CreateView):
     form_class = JoinForm
     success_url = '/events'
 
+    def get_context_data(self, **kwargs):
+        context = super(JoinView, self).get_context_data(**kwargs)
+        context['event'] = Event.objects.get(pk=self.kwargs['event_id'])
+        return context
+
     def get_initial(self):
         return {'event': Event.objects.get(pk=self.kwargs['event_id'])}

--- a/events/views.py
+++ b/events/views.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
+
 from events.models import Event, Participant
 from events.forms import JoinForm
 from django.views.generic import CreateView, DetailView, ListView
@@ -18,8 +21,14 @@ class JoinView(CreateView):
 
     def get_context_data(self, **kwargs):
         context = super(JoinView, self).get_context_data(**kwargs)
-        context['event'] = Event.objects.get(pk=self.kwargs['event_id'])
+        context['event'] = self.event
         return context
 
     def get_initial(self):
-        return {'event': Event.objects.get(pk=self.kwargs['event_id'])}
+        # Get initial gets run before get_context_data()
+        # Raise a 404 if it does not exist
+        try:
+            self.event = Event.objects.get(pk=self.kwargs['event_id'])
+        except Event.DoesNotExist:
+            raise Http404("The event does not exist")
+        return {'event': self.event}

--- a/livelobby/settings.py
+++ b/livelobby/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'livelobby.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,10 @@
+{% load static %}
+<html>
+    <head>
+            <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+    </head>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html>
     <head>
             <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+            <title>{% block title %}{% endblock %}</title>
     </head>
     <body>
         {% block content %}


### PR DESCRIPTION
Added a page under `/events/<event_id>/join` that allows users to join an event. A participant model instance is created when the user enters their name.

![join-form](https://user-images.githubusercontent.com/16263268/44615455-f20b3800-a87d-11e8-90dd-39b225e103f5.png)

![join-form-full](https://user-images.githubusercontent.com/16263268/44615454-f20b3800-a87d-11e8-8d3f-06b43049d246.png)

![join-form-empty](https://user-images.githubusercontent.com/16263268/44615453-f172a180-a87d-11e8-9ca8-18de45f77e53.png)

This form redirects to /events/<event_id>/ after a successful submission. See issue #5 for more details. 