### PR TITLE
Issue 11

### DIFF
--- a/events/static/events/event_list.css
+++ b/events/static/events/event_list.css
@@ -26,7 +26,7 @@
 #livelobby_text {
     text-transform: capitalize;
     font-size: 15pt;
-    margin: 6px 0px 0px 10px; 
+    margin: 6px 0px 0px 10px;
 }
 
 #guild_logo {
@@ -37,7 +37,7 @@
 }
 
 .events-container {
-    /* 
+    /*
     Defines the container for the grid items (events)
     Opens up the possibility to have multiple types of view later
     */
@@ -55,17 +55,17 @@
 }
 
 .event {
-    /* 
+    /*
     CSS for EventView here
     */
 
     /*Essential style*/
     border-style: outset;
     background-color: white;
-    
+
     /*Rounded corners*/
-    border-radius: 4px 4px 8px 8px;
-    
+    border-radius: 25px;
+
     /*
     Placeholder properties
     When real CSS for EventView is created, remove these properties

--- a/events/templates/events/event_list.html
+++ b/events/templates/events/event_list.html
@@ -11,32 +11,58 @@
 {% endblock %}
 
 {% block content %}
-    
+  <head>
+    <!--Only makes use of events-container and event styles-->
+    <link rel="stylesheet" type="text/css" href="{% static 'events/event_list.css' %}">
+  </head>
+
     <!--Events Container Card-->
-    <div class="d-flex flex-column w-100 mw-100 px-2 py-2 bg-secondary">
-        {% for event in object_list %}
-            
-            <!-- EventView Card -->
-            <div class="card bg-light my-1">
-                
-                <!-- EventView Components -->
-                <div class="card-body d-flex flex-row justify-content-center">
-                    <!-- Place sub div tags for EventView in here -->
-                    <div>
-                        | {{ event.time }}
-                    </div>
-                    <div>
-                        | {{ event.name }} - Add EventView object here
-                    </div>
-                    <div>
-                        | Player count here |
-                    </div>
-                </div>
-    
-            </div>
-        {% empty %}
-            <!--Shouldn't be seen but just in case, better to show something than not-->
-            <div class="alert alert-info mx-auto" role="alert">There are no events yet... why not make your own?</div>
-        {% endfor %}
-    </div>
+    <div class="events-container bg-secondary">
+      {% for event in events %}
+       <div class="event">
+         <div class="card-group">
+           <!--Date/time card-->
+           <div class="card border-left-0 border-top-0 border-bottom-0">
+             <div class="card-block">
+               <h1 class="card-text">{{ event.date.day }}</h1>
+               <h3 class="card-text">{{ event.date.month|month_abbr|upper }}</h3>
+               <p class="card-text">{{ event.time }}</p>
+             </div>
+           </div>
+           <!--Event name, owner, description etc.-->
+           <div class="card border-top-0 border-bottom-0" style="flex-grow: 5">
+             <div class="card-block">
+               <h2 class="card-title">{{ event.name|upper }}</h2>
+               <p class="card-text"> {{ event.type }} -
+                 <!--Finds the event host in the list of participants-->
+                 {% for person in participants %}
+                  {% if person.type == "HOST" and person.event == event %}
+                   {{person.name}}
+                  {% endif %}
+                 {% endfor %}
+               </p>
+               <p class="card-text">{{ event.description }}</p>
+             </div>
+           </div>
+           <!--Current/max # of players and join/full button-->
+           <div class="card border-0">
+             <div class="card-block">
+               <h3 class="card-text">{{ groups|get_item:event }}/{{ event.max_size }}</h3>
+               <p class="card-text">Players</p>
+               {% if groups|get_item:event == event.max_size %}
+                <button type="button" class="btn btn-lg disabled btn-danger">FULL</button>
+               {% else %}
+               <a href={% url 'join_view' event_id=event.id %}>
+                 <button type="button" class="btn btn-lg btn-primary">Join</button>
+               </a>
+               {% endif %}
+             </div>
+           </div>
+         </div>
+       </div>
+       {% empty %}
+        <!--Shouldn't be seen but just in case, better to show something than not-->
+        <div class="alert alert-info mx-auto" role="alert">There are no events yet... why not make your own?</div>
+       {% endfor %}
+     </div>
 {% endblock %}

--- a/events/views.py
+++ b/events/views.py
@@ -5,19 +5,36 @@ from events.models import Event, Participant
 from events.forms import JoinForm, CreateEventForm
 from django.views.generic import CreateView, DetailView, ListView
 from django.shortcuts import render
+from django.template.defaulttags import register
+import calendar
 
 class EventListView(ListView):
     template_name = 'events/event_list.html'
     model = Event
 
+    # Used to get from the 'groups' dictionary
+    @register.filter
+    def get_item(dictionary, key):
+        return dictionary.get(key)
+
+    # Converts a given month number to an abbreviation (eg. 8 = Aug)
+    @register.filter
+    def month_abbr(month_num):
+        return calendar.month_abbr[int(month_num)]
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        grouped_participants = {}
+        # Count how many users are in each event
+        for e in Event.objects.all():
+            grouped_participants[e] = (e.initial_size +
+            len(Participant.objects.filter(event=e))-1)
+        context.update({
+            'events': Event.objects.order_by('date', 'time'),
+            'participants': Participant.objects.all(),
+            'groups': grouped_participants
+        })
         return context
-
-    def get_queryset(self):
-        # Sort the events by date ascending
-        events_by_date = Event.objects.order_by('time')
-        return events_by_date
 
 class EventView(DetailView):
     template_name = 'events/event.html'


### PR DESCRIPTION
Added event cards to the main page using bootstrap components.

A slight difference between the MVP and the information provided by the _Event_ model is the difference between the _event name_, the _game name_ and the _type of event_. The MVP features the _game name_ as the primary heading for each card and the _event name_ as a subheading. The _Event_ model includes an _event name_ and _event type_ so I have used the _event name_ as the primary header and the _event type_ as the subheading in the place of the _event name_ in the MVP.

So far I've only tested the view on browsers so I'm not sure if there will be issues with phone/tablet viewing.