### PR TITLE
Add django-sslserver to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ whitenoise = "==3.3.1"
 [dev-packages]
 
 
+django-sslserver = "*"
 
 [requires]
 


### PR DESCRIPTION
In development INSTALLED_APPS here:
https://github.com/mrpresidentjk/livelobby/blob/develop/livelobby/settings/development.py#L15

Added to development Pipfile requirements.